### PR TITLE
Update RSCodeGenerator.swift

### DIFF
--- a/Source/RSCodeGenerator.swift
+++ b/Source/RSCodeGenerator.swift
@@ -226,11 +226,9 @@ public class RSAbstractCodeGenerator : RSCodeGenerator {
             x = (targetSize.width  - width)  / 2.0
             y = (targetSize.height - height) / 2.0
         } else  { // contents scaled to fit with fixed aspect. remainder is transparent
-            let targtLength  = (targetSize.height < targetSize.width)   ? targetSize.height  : targetSize.width
-            let sourceLength = (source.size.height > source.size.width) ? source.size.height : source.size.width
-            let fillScale = targtLength / sourceLength
-            width = source.size.width * fillScale
-            height = source.size.height * fillScale
+            let scaledRect = AVMakeRectWithAspectRatioInsideRect(source.size, CGRectMake(0.0, 0.0, targetSize.width, targetSize.height))
+            width = scaledRect.width
+            height = scaledRect.height
             if (contentMode == UIViewContentMode.ScaleAspectFit
                 || contentMode == UIViewContentMode.Redraw
                 || contentMode == UIViewContentMode.Center) {


### PR DESCRIPTION
Use foundation method to calculate maximum resized size within new bounding rect.

Reasoning for change is that when I had bar codes more wide than tall, previous scale would not use all the width even though bounding height still had room