### PR TITLE
Fixed wrong videoOrientation after front/back camera switch

### DIFF
--- a/RSBarcodesSample/RSBarcodesSample.xcodeproj/project.pbxproj
+++ b/RSBarcodesSample/RSBarcodesSample.xcodeproj/project.pbxproj
@@ -455,6 +455,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
 				SWIFT_VERSION = 3.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
 		};
@@ -472,6 +473,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
 				SWIFT_VERSION = 3.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
 		};

--- a/Source/RSCodeReaderViewController.swift
+++ b/Source/RSCodeReaderViewController.swift
@@ -62,6 +62,7 @@ open class RSCodeReaderViewController: UIViewController, AVCaptureMetadataOutput
                 self.device = device
             }
             self.setupCamera()
+			self.view.setNeedsLayout()
             self.session.startRunning()
             if let device = self.device {
                 return device.position


### PR DESCRIPTION
When switching between front/back camera, then the initial video orientation is 90 degree rotated.

Solution was to invoke the `RSCodeReaderViewController.viewDidLayoutSubviews()` after switching front/back, causing the `videoOrientation` to be updated.

My setup is this:

 * iPad runs: iOS 10.1.1 (14B100)
 * iPad Model: ML0G2KN/A
 * Xcode 8.2.1 (8C1002)