### PR TITLE
Added ExtCode39 validation

### DIFF
--- a/Source/RSExtendedCode39Generator.swift
+++ b/Source/RSExtendedCode39Generator.swift
@@ -135,7 +135,17 @@ open class RSExtendedCode39Generator: RSCode39Generator {
     }
     
     override open func isValid(_ contents: String) -> Bool {
-        return contents.length() > 0
+        if contents.length() > 0 {
+            let encContents = self.encodeContents(contents)
+            for character in encContents.characters {
+                let location = CODE39_ALPHABET_STRING.location(String(character))
+                if location == NSNotFound {
+                    return false
+                }
+            }
+            return true
+        }
+        return false
     }
     
     override open func barcode(_ contents: String) -> String {


### PR DESCRIPTION
There are still cases where the encodeContents will produce characters that cannot be converted, so a validation is required.
For instance, try to serialize an iOS contact (CNContact) to a VCard string: That will fail to generate but pass the previous validation code.