### PR TITLE
Disable code coverage

### DIFF
--- a/RSBarcodes.xcodeproj/xcshareddata/xcschemes/RSBarcodes.xcscheme
+++ b/RSBarcodes.xcodeproj/xcshareddata/xcschemes/RSBarcodes.xcscheme
@@ -41,7 +41,7 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
-      codeCoverageEnabled = "YES">
+      codeCoverageEnabled = "NO">
       <Testables>
          <TestableReference
             skipped = "NO">


### PR DESCRIPTION
Code coverage has to be disabled for Carthage to work with Xcode 9.

Check https://github.com/Carthage/Carthage/issues/2056 and https://github.com/Carthage/Carthage/pull/2057.