### PR TITLE
Fix issue: 'substring(to:)' is deprecated.

### DIFF
--- a/RSBarcodes.xcodeproj/project.pbxproj
+++ b/RSBarcodes.xcodeproj/project.pbxproj
@@ -341,7 +341,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_SWIFT3_OBJC_INFERENCE = On;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
 				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
@@ -361,7 +361,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.pdq.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-				SWIFT_SWIFT3_OBJC_INFERENCE = On;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
 				SWIFT_VERSION = 4.0;
 			};
 			name = Release;

--- a/Source/UIColorExtension.swift
+++ b/Source/UIColorExtension.swift
@@ -87,7 +87,7 @@ extension UIColor {
             throw UIColorInputError.missingHashMarkAsPrefix
         }
         
-        let hexString: String = rgba.substring(from: rgba.characters.index(rgba.startIndex, offsetBy: 1))
+        let hexString = String(rgba.suffix(from: rgba.characters.index(rgba.startIndex, offsetBy: 1)))
         var hexValue:  UInt32 = 0
         
         guard Scanner(string: hexString).scanHexInt32(&hexValue) else {


### PR DESCRIPTION
Fix Xcode 9 issue: 

> 'substring(to:)' is deprecated