### PR TITLE
Access control: open'ed things that was private

### DIFF
--- a/Source/RSCodeReaderViewController.swift
+++ b/Source/RSCodeReaderViewController.swift
@@ -14,7 +14,7 @@ open class RSCodeReaderViewController: UIViewController, AVCaptureMetadataOutput
     open var device = AVCaptureDevice.default(for: AVMediaType.video)
     open var output = AVCaptureMetadataOutput()
     open var session = AVCaptureSession()
-    var videoPreviewLayer: AVCaptureVideoPreviewLayer?
+    open var videoPreviewLayer: AVCaptureVideoPreviewLayer?
     
     open var focusMarkLayer = RSFocusMarkLayer()
     open var cornersLayer = RSCornersLayer()

--- a/Source/RSCodeReaderViewController.swift
+++ b/Source/RSCodeReaderViewController.swift
@@ -98,9 +98,9 @@ open class RSCodeReaderViewController: UIViewController, AVCaptureMetadataOutput
         return false
     }
     
-    // MARK: Private methods
+    // MARK: Internal methods
     
-    func captureDevice() -> AVCaptureDevice? {
+    open func captureDevice() -> AVCaptureDevice? {
         if let device = self.device {
             if device.position == AVCaptureDevice.Position.back {
                 for device: AVCaptureDevice in AVCaptureDevice.devices(for: AVMediaType.video) {
@@ -119,7 +119,7 @@ open class RSCodeReaderViewController: UIViewController, AVCaptureMetadataOutput
         return nil
     }
     
-    func setupCamera() {
+    open func setupCamera() {
         var error : NSError?
         let input: AVCaptureDeviceInput!
         
@@ -209,7 +209,7 @@ open class RSCodeReaderViewController: UIViewController, AVCaptureMetadataOutput
         }
     }
     
-    func reloadVideoOrientation() {
+    open func reloadVideoOrientation() {
         guard let videoPreviewLayer = self.videoPreviewLayer else {
             return
         }
@@ -230,7 +230,7 @@ open class RSCodeReaderViewController: UIViewController, AVCaptureMetadataOutput
         videoPreviewLayer.removeAllAnimations()
     }
     
-    func autoUpdateLensPosition() {
+    open func autoUpdateLensPosition() {
         self.lensPosition += 0.01
         if self.lensPosition > 1 {
             self.lensPosition = 0


### PR DESCRIPTION
RSBarcodes_Swift is a great framework. I use it in 2 projects. It's robust and easy.

In this PR I have inserted the `open` keyword a few places. In particular I need to access the internal `videoPreviewLayer` ivar and I need to override the `reloadVideoOrientation()` function. 

Yesterday+today I have been writing code that restricts the scanning area to a tiny box centered on the screen. For this purpose Apple provides [`AVCaptureMetadataOutput.rectOfInterest`](https://developer.apple.com/documentation/avfoundation/avcapturemetadataoutput/1616291-rectofinterest). I had to figure out how to compute the `rectOfInterest` using camera coordinates in the range 0..1. It was especially challenging dealing with orientation changes on iPad. Invoking `updateRectOfInterest()` too early and then the coordinates would be wrong. I have tested on iPad Pro and on iPhone6s and the `rectOfInterest` is working.

My subclass looks like this:

```
class MyScannerViewController: RSCodeReaderViewController {
    @IBOutlet weak var restrictedScanArea: UIView!

    override func viewDidLayoutSubviews() {
        super.viewDidLayoutSubviews()
        updateRectOfInterest()
    }

    override func reloadVideoOrientation() {
        super.reloadVideoOrientation()
        updateRectOfInterest()
    }

    func updateRectOfInterest() {
        guard let videoPreviewLayer: AVCaptureVideoPreviewLayer = self.videoPreviewLayer else {
            return
        }
        let scanRect = self.restrictedScanArea.frame
        /// Convert from display coordinates (pixels) to camera coordinates (0..1 range)
        /// scanRect: (515.0, 443.0, 336.0, 138.0)  rectOfInterest: (0.408, 0.433, 0.185, 0.135)
        output.rectOfInterest = videoPreviewLayer.metadataOutputRectConverted(fromLayerRect: scanRect)
    }
}

```


---

I can see that there are other people that have asked about `rectOfInterest`, see [issue 76](https://github.com/yeahdongcn/RSBarcodes_Swift/issues/76) and [issue 110](https://github.com/yeahdongcn/RSBarcodes_Swift/issues/110).
