### PR TITLE
Fix Swift 4 implementation

### DIFF
--- a/RSBarcodes_Swift.podspec
+++ b/RSBarcodes_Swift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "RSBarcodes_Swift"
-  s.version      = "4.2.0"
+  s.version      = "4.2.1"
   s.summary      = "1D and 2D barcodes reader and generators for iOS 8 with delightful controls. Now Swift. "
   s.homepage     = "https://github.com/yeahdongcn/RSBarcodes_Swift"
   s.license      = { :type => 'MIT', :file => 'LICENSE.md' }
@@ -10,4 +10,5 @@ Pod::Spec.new do |s|
   s.source_files = 'Source/*.{swift,h,m}'
   s.frameworks   = ['CoreImage', 'AVFoundation', 'QuartzCore']
   s.requires_arc = true
+  s.swift_version = "4.0"
 end

--- a/Source/RSCodeReaderViewController.swift
+++ b/Source/RSCodeReaderViewController.swift
@@ -376,9 +376,9 @@ open class RSCodeReaderViewController: UIViewController, AVCaptureMetadataOutput
 	
 	override open func viewDidDisappear(_ animated: Bool) {
 		super.viewDidDisappear(animated)
-		
-        NotificationCenter.default.removeObserver(self, name: UIApplication.willEnterForegroundNotification, object: nil)
-        NotificationCenter.default.removeObserver(self, name: UIApplication.didEnterBackgroundNotification, object: nil)
+
+        NotificationCenter.default.removeObserver(self, name: NSNotification.Name.UIApplicationWillEnterForeground, object: nil)
+        NotificationCenter.default.removeObserver(self, name: NSNotification.Name.UIApplicationDidEnterBackground, object: nil)
 		if !Platform.isSimulator {
 			self.session.stopRunning()
 		}


### PR DESCRIPTION
This adds swift version property to the podspec, as well as using the appropriate notification names. It fixes some discrepancies that were preventing this from building in Xcode 10.1.

This pod was preventing my project from building without these updates. Maybe this will help someone else too.