### PR TITLE
Fix corners layer

### DIFF
--- a/Source/RSCornersLayer.swift
+++ b/Source/RSCornersLayer.swift
@@ -22,6 +22,8 @@ open class RSCornersLayer: CALayer {
     }
     
     override open func draw(in ctx: CGContext) {
+        guard let cornerPointsArray = cornersArray as? [[CGPoint]] else { return }
+
         objc_sync_enter(self)
         
         ctx.saveGState()
@@ -32,19 +34,15 @@ open class RSCornersLayer: CALayer {
         ctx.setStrokeColor(self.strokeColor)
         ctx.setLineWidth(self.strokeWidth)
         
-        for corners in self.cornersArray {
-            for i in 0...corners.count-1 {
-                var idx = i
-                if i == corners.count-1 {
-                    idx = 0
-                }
-                let point = corners[idx] as! CGPoint
-                if i == 0 {
+        for corners in cornerPointsArray {
+            for (idx, point) in corners.enumerated() {
+                if idx == 0 {
                     ctx.move(to: point)
                 } else {
                     ctx.addLine(to: point)
                 }
             }
+            ctx.closePath()
         }
         
         ctx.drawPath(using: CGPathDrawingMode.fillStroke)


### PR DESCRIPTION
- add close path when drawing each bounding box for corners layer
- fix loop index and simplify logic
- add guard to cast corners to CGPoint arrays

Should also fix this issue: https://github.com/yeahdongcn/RSBarcodes_Swift/issues/105