### PR TITLE
Added Mac Catalyst support

### DIFF
--- a/RSBarcodesSample/RSBarcodesSample/BarcodeDisplayViewController.swift
+++ b/RSBarcodesSample/RSBarcodesSample/BarcodeDisplayViewController.swift
@@ -16,7 +16,7 @@ import RSBarcodes
 class BarcodeDisplayViewController: UIViewController {
     @IBOutlet weak var imageDisplayed: UIImageView!
     
-    var contents: String = "https://github.com/VMwareFusion/nautilus"
+    var contents: String = "https://github.com/yeahdongcn/"
     
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/Source/RSCode128Generator.swift
+++ b/Source/RSCode128Generator.swift
@@ -15,6 +15,7 @@ public enum RSCode128GeneratorCodeTable: Int {
 
 // http://www.barcodeisland.com/code128.phtml
 // http://courses.cs.washington.edu/courses/cse370/01au/minirproject/BarcodeBattlers/barcodes.html
+@available(macCatalyst 14.0, *)
 open class RSCode128Generator: RSAbstractCodeGenerator, RSCheckDigitGenerator {
     class RSCode128GeneratorAutoCodeTable {
         var startCodeTable = RSCode128GeneratorCodeTable.auto

--- a/Source/RSCode39Generator.swift
+++ b/Source/RSCode39Generator.swift
@@ -12,6 +12,7 @@ let CODE39_ALPHABET_STRING = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ-. $/+%*"
 
 // http://www.barcodesymbols.com/code39.htm
 // http://www.barcodeisland.com/code39.phtml
+@available(macCatalyst 14.0, *)
 open class RSCode39Generator: RSAbstractCodeGenerator {
     let CODE39_CHARACTER_ENCODINGS = [
         "1010011011010",

--- a/Source/RSCode39Mod43Generator.swift
+++ b/Source/RSCode39Mod43Generator.swift
@@ -10,6 +10,7 @@ import UIKit
 
 // http://www.barcodesymbols.com/code39.htm
 // http://www.barcodeisland.com/code39.phtml
+@available(macCatalyst 14.0, *)
 open class RSCode39Mod43Generator: RSCode39Generator, RSCheckDigitGenerator {
     
     // MARK: RSAbstractCodeGenerator

--- a/Source/RSCode93Generator.swift
+++ b/Source/RSCode93Generator.swift
@@ -9,6 +9,7 @@
 import UIKit
 
 // http://www.barcodeisland.com/code93.phtml
+@available(macCatalyst 14.0, *)
 open class RSCode93Generator: RSAbstractCodeGenerator, RSCheckDigitGenerator {
     let CODE93_ALPHABET_STRING    = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ-. $/+%abcd*"
     

--- a/Source/RSCodeDataMatrixGenerator.swift
+++ b/Source/RSCodeDataMatrixGenerator.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 
+@available(macCatalyst 14.0, *)
 class RSCodeDataMatrixGenerator: RSAbstractCodeGenerator {
 
 }

--- a/Source/RSCodeGenerator.swift
+++ b/Source/RSCodeGenerator.swift
@@ -23,6 +23,7 @@ public enum InputCorrectionLevel: String {
 }
 
 // Code generators are required to provide these two functions.
+@available(macCatalyst 14.0, *)
 public protocol RSCodeGenerator {
     /** The fill (background) color of the generated barcode. */
     var fillColor: UIColor {get set}
@@ -54,6 +55,7 @@ public protocol RSCheckDigitGenerator {
 }
 
 // Abstract code generator, provides default functions for validations and generations.
+@available(macCatalyst 14.0, *)
 open class RSAbstractCodeGenerator : RSCodeGenerator {
     
     open var fillColor: UIColor = UIColor.white

--- a/Source/RSCodeGenerator.swift
+++ b/Source/RSCodeGenerator.swift
@@ -244,7 +244,7 @@ open class RSAbstractCodeGenerator : RSCodeGenerator {
         return target
     }
     
-    open class func resizeImage(_ source:UIImage, targetSize:CGSize, contentMode:UIView.ContentMode) -> UIImage? {
+    open class func resizeImage(_ source:UIImage, targetSize:CGSize, contentMode:UIView.ContentMode, scale:CGFloat? = nil) -> UIImage? {
         var x: CGFloat = 0
         var y: CGFloat = 0
         var width = targetSize.width
@@ -295,7 +295,7 @@ open class RSAbstractCodeGenerator : RSCodeGenerator {
             }
         }
         
-        UIGraphicsBeginImageContextWithOptions(targetSize, false, 0)
+        UIGraphicsBeginImageContextWithOptions(targetSize, false, scale ?? 0)
         guard let context = UIGraphicsGetCurrentContext() else { return nil }
         context.interpolationQuality = CGInterpolationQuality.none
         source.draw(in: CGRect(x: x, y: y, width: width, height: height))

--- a/Source/RSCodeGenerator.swift
+++ b/Source/RSCodeGenerator.swift
@@ -109,7 +109,7 @@ open class RSAbstractCodeGenerator : RSCodeGenerator {
         // Height               = 28
         let width = length + 4
         let size = CGSize(width: CGFloat(width), height: 28)
-        UIGraphicsBeginImageContextWithOptions(size, false, 0)
+        UIGraphicsBeginImageContextWithOptions(size, false, 1)
         if let context = UIGraphicsGetCurrentContext() {
             context.setShouldAntialias(false)
             

--- a/Source/RSCodeReaderViewController.swift
+++ b/Source/RSCodeReaderViewController.swift
@@ -9,6 +9,7 @@
 import AVFoundation
 import UIKit
 
+@available(macCatalyst 14.0, *)
 open class RSCodeReaderViewController: UIViewController, AVCaptureMetadataOutputObjectsDelegate {
    @objc open var device = AVCaptureDevice.default(for: AVMediaType.video)
    @objc open var output = AVCaptureMetadataOutput()

--- a/Source/RSCodeReaderViewController.swift
+++ b/Source/RSCodeReaderViewController.swift
@@ -10,6 +10,7 @@ import AVFoundation
 import UIKit
 
 @available(macCatalyst 14.0, *)
+@available(iOSApplicationExtension, unavailable)
 open class RSCodeReaderViewController: UIViewController, AVCaptureMetadataOutputObjectsDelegate {
    @objc open var device = AVCaptureDevice.default(for: AVMediaType.video)
    @objc open var output = AVCaptureMetadataOutput()

--- a/Source/RSEANGenerator.swift
+++ b/Source/RSEANGenerator.swift
@@ -12,6 +12,7 @@ public let RSBarcodesTypeISBN13Code = "com.pdq.rsbarcodes.isbn13"
 public let RSBarcodesTypeISSN13Code = "com.pdq.rsbarcodes.issn13"
 
 // http://blog.sina.com.cn/s/blog_4015406e0100bsqk.html
+@available(macCatalyst 14.0, *)
 open class RSEANGenerator: RSAbstractCodeGenerator {
     var length = 0
     // 'O' for odd and 'E' for even
@@ -100,18 +101,21 @@ open class RSEANGenerator: RSAbstractCodeGenerator {
     }
 }
 
+@available(macCatalyst 14.0, *)
 class RSEAN8Generator: RSEANGenerator {
     init() {
         super.init(length: 8)
     }
 }
 
+@available(macCatalyst 14.0, *)
 class RSEAN13Generator: RSEANGenerator {
     init() {
         super.init(length: 13)
     }
 }
 
+@available(macCatalyst 14.0, *)
 class RSISBN13Generator: RSEAN13Generator {
     override func isValid(_ contents: String) -> Bool {
         // http://www.appsbarcode.com/ISBN.php
@@ -119,6 +123,7 @@ class RSISBN13Generator: RSEAN13Generator {
     }
 }
 
+@available(macCatalyst 14.0, *)
 class RSISSN13Generator: RSEAN13Generator {
     override func isValid(_ contents: String) -> Bool {
         // http://www.appsbarcode.com/ISSN.php

--- a/Source/RSExtendedCode39Generator.swift
+++ b/Source/RSExtendedCode39Generator.swift
@@ -12,6 +12,7 @@ public let RSBarcodesTypeExtendedCode39Code = "com.pdq.rsbarcodes.code39.ext"
 
 // http://www.barcodesymbols.com/code39.htm
 // http://www.barcodeisland.com/code39.phtml
+@available(macCatalyst 14.0, *)
 open class RSExtendedCode39Generator: RSCode39Generator {
     func encodeContents(_ contents: String) -> String {
         var encodedContents = ""

--- a/Source/RSITF14Generator.swift
+++ b/Source/RSITF14Generator.swift
@@ -10,6 +10,7 @@ import UIKit
 
 // http://www.gs1au.org/assets/documents/info/user_manuals/barcode_technical_details/ITF_14_Barcode_Structure.pdf
 // http://www.barcodeisland.com/int2of5.phtml
+@available(macCatalyst 14.0, *)
 open class RSITF14Generator: RSITFGenerator {
     override open func isValid(_ contents: String) -> Bool {
         return super.isValid(contents) && contents.length() == 14

--- a/Source/RSITFGenerator.swift
+++ b/Source/RSITFGenerator.swift
@@ -9,6 +9,7 @@
 import UIKit
 
 // http://www.barcodeisland.com/int2of5.phtml
+@available(macCatalyst 14.0, *)
 open class RSITFGenerator: RSAbstractCodeGenerator {
     let ITF_CHARACTER_ENCODINGS = [
         "00110",

--- a/Source/RSUPCEGenerator.swift
+++ b/Source/RSUPCEGenerator.swift
@@ -12,6 +12,7 @@ import UIKit
 // http://mdn.morovia.com/kb/UPCE-Specification-10634.html
 // http://mdn.morovia.com/kb/UPCA-Specification-10632.html
 // http://www.barcodeisland.com/upce.phtml
+@available(macCatalyst 14.0, *)
 open class RSUPCEGenerator: RSAbstractCodeGenerator, RSCheckDigitGenerator {
     let UPCE_ODD_ENCODINGS = [
         "0001101",

--- a/Source/RSUnifiedCodeGenerator.swift
+++ b/Source/RSUnifiedCodeGenerator.swift
@@ -10,6 +10,7 @@ import Foundation
 import UIKit
 import AVFoundation
 
+@available(macCatalyst 14.0, *)
 open class RSUnifiedCodeGenerator: RSCodeGenerator {
     
     open var isBuiltInCode128GeneratorSelected = false
@@ -89,4 +90,5 @@ open class RSUnifiedCodeGenerator: RSCodeGenerator {
     }
 }
 
+@available(macCatalyst 14.0, *)
 let UnifiedCodeGeneratorSharedInstance = RSUnifiedCodeGenerator()

--- a/Source/RSUnifiedCodeValidator.swift
+++ b/Source/RSUnifiedCodeValidator.swift
@@ -9,6 +9,7 @@
 import Foundation
 import AVFoundation
 
+@available(macCatalyst 14.0, *)
 open class RSUnifiedCodeValidator {
     open class var shared: RSUnifiedCodeValidator {
         return UnifiedCodeValidatorSharedInstance
@@ -52,4 +53,6 @@ open class RSUnifiedCodeValidator {
         return codeGenerator!.isValid(contents)
     }
 }
+
+@available(macCatalyst 14.0, *)
 let UnifiedCodeValidatorSharedInstance = RSUnifiedCodeValidator()

--- a/Source/RSUnifiedCodeValidator.swift
+++ b/Source/RSUnifiedCodeValidator.swift
@@ -38,8 +38,8 @@ open class RSUnifiedCodeValidator {
             codeGenerator = RSCode93Generator()
         case AVMetadataObject.ObjectType.code128.rawValue:
             codeGenerator = RSCode128Generator()
-        case AVMetadataObject.ObjectType.dataMatrix.rawValue:
-            codeGenerator = RSCodeDataMatrixGenerator()
+        // case AVMetadataObject.ObjectType.dataMatrix.rawValue:
+        //     codeGenerator = RSCodeDataMatrixGenerator()
         case RSBarcodesTypeISBN13Code:
             codeGenerator = RSISBN13Generator()
         case RSBarcodesTypeISSN13Code:

--- a/Source/RSUnifiedCodeValidator.swift
+++ b/Source/RSUnifiedCodeValidator.swift
@@ -38,8 +38,10 @@ open class RSUnifiedCodeValidator {
             codeGenerator = RSCode93Generator()
         case AVMetadataObject.ObjectType.code128.rawValue:
             codeGenerator = RSCode128Generator()
-        // case AVMetadataObject.ObjectType.dataMatrix.rawValue:
-        //     codeGenerator = RSCodeDataMatrixGenerator()
+        /** TODO: Uncomment this once DataMatrix generator is implemented.
+        case AVMetadataObject.ObjectType.dataMatrix.rawValue:
+            codeGenerator = RSCodeDataMatrixGenerator()
+         */
         case RSBarcodesTypeISBN13Code:
             codeGenerator = RSISBN13Generator()
         case RSBarcodesTypeISSN13Code:


### PR DESCRIPTION
- Apple has marked much of the AVFoundation API as available on “Mac Catalyst 14.0+” so some available annotation are required.
- Added support for specifying the resizing scale.
- Set the initial rendering scale to 1: the initial barcode rendering scale should be set 1.0 to ensure the same barcode base image is generated in all devices (currently devices with scale x2 and x3 generate slightly different barcodes).