### PR TITLE
Make size of generated barcode the same aspect ratio as the target

### DIFF
--- a/Source/RSCodeGenerator.swift
+++ b/Source/RSCodeGenerator.swift
@@ -104,9 +104,13 @@ open class RSAbstractCodeGenerator : RSCodeGenerator {
         // Top spacing          = 1.5
         // Bottom spacing       = 2
         // Left & right spacing = 2
-        // Height               = 28
         let width = length + 4
-        let size = CGSize(width: CGFloat(width), height: 28)
+        // Calculate the correct aspect ratio, so that the resulting image can be resized to the target size
+        var height = width
+        if let targetSize = targetSize {
+            height = Int(targetSize.height / targetSize.width * CGFloat(width))
+        }
+        let size = CGSize(width: CGFloat(width), height: CGFloat(height))
         UIGraphicsBeginImageContextWithOptions(size, false, 0)
         if let context = UIGraphicsGetCurrentContext() {
             context.setShouldAntialias(false)

--- a/Source/RSCodeGenerator.swift
+++ b/Source/RSCodeGenerator.swift
@@ -12,6 +12,7 @@ import AVFoundation
 import CoreImage
 
 let DIGITS_STRING = "0123456789"
+let BARCODE_DEFAULT_HEIGHT = 28
 
 // Controls the amount of additional data encoded in the output image to provide error correction.
 // Higher levels of error correction result in larger output images but allow larger areas of the code to be damaged or obscured without.
@@ -106,7 +107,7 @@ open class RSAbstractCodeGenerator : RSCodeGenerator {
         // Left & right spacing = 2
         let width = length + 4
         // Calculate the correct aspect ratio, so that the resulting image can be resized to the target size
-        var height = width
+        var height = BARCODE_DEFAULT_HEIGHT
         if let targetSize = targetSize {
             height = Int(targetSize.height / targetSize.width * CGFloat(width))
         }


### PR DESCRIPTION
Calculating the height given the width of the barcode. The same aspect ration of the given target size is used, so the the resulting image size can be scaled without problems.